### PR TITLE
Unicode handling improvements on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ exe = executable(
   'src/szx_state.c',
   'src/tape.c',
   'src/ula.c',
+  'src/unicode.c',
   'src/video_sdl.c',
   'src/z80.c',
   'ayumi/ayumi.c',

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -86,7 +86,7 @@ keyval_cleanup:
 
 int config_load_file(CfgData_t *cfg, char *path)
 {
-    FILE *f = fopen(path, "r");
+    FILE *f = fopen_utf8(path, "r");
     if (f == NULL) {
         return -1;
     }
@@ -138,7 +138,7 @@ int config_load_file(CfgData_t *cfg, char *path)
 
 int config_save_file(CfgData_t *cfg, char *path)
 {
-    FILE *f = fopen(path, "w");
+    FILE *f = fopen_utf8(path, "w");
     if (f == NULL) {
         return -1;
     }

--- a/src/file.c
+++ b/src/file.c
@@ -258,25 +258,20 @@ char *file_read_line(FILE *f)
     return str;
 }
 
-// Lifted from https://github.com/Photosounder/fopen_utf8
+// Lifted and adapted from https://github.com/Photosounder/fopen_utf8
 // "[...] just put it in your code, who cares where it came from". I do :')
-FILE *fopen_utf8(const char *path, const char *mode)
-{
 #ifdef _WIN32
-    wchar_t *wpath, wmode[8];
+FILE *fopen_utf8_win32(const char *path, const wchar_t *mode)
+{
+    wchar_t *wpath;
     FILE *file;
-
-    if (utf8_to_utf16(mode, (uint16_t *)wmode) == NULL)
-        return NULL;
 
     wpath = utf8_to_utf16(path, NULL);
     if (wpath == NULL)
         return NULL;
 
-    file = _wfopen(wpath, wmode);
+    file = _wfopen(wpath, mode);
     free(wpath);
     return file;
-#else
-    return fopen(path, mode);
-#endif
 }
+#endif

--- a/src/file.c
+++ b/src/file.c
@@ -266,10 +266,10 @@ FILE *fopen_utf8(const char *path, const char *mode)
     wchar_t *wpath, wmode[8];
     FILE *file;
 
-    if (utf8_to_utf16((const uint8_t *)mode, (uint16_t *)wmode) == NULL)
+    if (utf8_to_utf16(mode, (uint16_t *)wmode) == NULL)
         return NULL;
 
-    wpath = (wchar_t *)utf8_to_utf16((const uint8_t *)path, NULL);
+    wpath = utf8_to_utf16(path, NULL);
     if (wpath == NULL)
         return NULL;
 

--- a/src/file.h
+++ b/src/file.h
@@ -20,3 +20,4 @@ void file_free_list(char *list[]);
 char **file_list_directory_files(char *path);
 enum FileType file_detect_type(char *path);
 char *file_read_line(FILE *f);
+FILE *fopen_utf8(const char *path, const char *mode);

--- a/src/file.h
+++ b/src/file.h
@@ -20,4 +20,10 @@ void file_free_list(char *list[]);
 char **file_list_directory_files(char *path);
 enum FileType file_detect_type(char *path);
 char *file_read_line(FILE *f);
-FILE *fopen_utf8(const char *path, const char *mode);
+
+#ifdef _WIN32
+    FILE *fopen_utf8_win32(const char *path, const wchar_t *mode);
+    #define fopen_utf8(path, mode) fopen_utf8_win32(path, L ## mode)
+#else
+    #define fopen_utf8(path, mode) fopen(path, mode)
+#endif

--- a/src/log.c
+++ b/src/log.c
@@ -5,6 +5,8 @@
 #include <time.h>
 #if defined(_WIN32) && defined(PLATFORM_WIN32)
     #include <Windows.h>
+    #include <stdlib.h>
+    #include "unicode.h"
 #endif
 
 static const char prefix_err[] = "err: ";
@@ -48,7 +50,12 @@ void dlog(enum LogLevel l, char fmt[], ...)
     
 #if defined(_WIN32) && defined(PLATFORM_WIN32)
     if (l == LOG_ERR && !force_errsilent) {
-        MessageBoxA(GetActiveWindow(), msg, "Error", MB_OK | MB_ICONERROR);
+        wchar_t *str = utf8_to_utf16(msg, NULL);
+        if (str == NULL) {
+            return;
+        }
+        MessageBoxW(GetActiveWindow(), str, L"Error", MB_OK | MB_ICONERROR);
+        free(str);
     }
 #endif
 }

--- a/src/machine_test.c
+++ b/src/machine_test.c
@@ -63,7 +63,7 @@ static struct MachineTest test = { 0 };
 
 static KeyboardMacro_t *parse_macro(const char *path)
 {
-    FILE *f = fopen(path, "r");
+    FILE *f = fopen_utf8(path, "r");
     if (f == NULL) {
         return NULL;
     }
@@ -242,7 +242,7 @@ int machine_test_open(const char *path)
     }
     if (test.test_print) {
         file_path_append(buf, path, "print.txt.tmp", sizeof(buf));
-        test.print = fopen(buf, "wb+");
+        test.print = fopen_utf8(buf, "wb+");
         if (test.print == NULL) {
             dlog(LOG_ERR, "Failed to open file \"%s\" for write", buf);
             return -8;
@@ -292,10 +292,10 @@ static void finish_hash(XXH64_state_t *s, const char *name)
     uint64_t expected;
     char buf[2048];
     file_path_append(buf, test.dir, name, sizeof(buf));
-    FILE *f = fopen(buf, "rb");
+    FILE *f = fopen_utf8(buf, "rb");
     if (f == NULL) {
         dlog(LOG_WARN, "Failed to open hash file \"%s\", attempting to create", name);
-        f = fopen(buf, "wb");
+        f = fopen_utf8(buf, "wb");
         if (f == NULL) {
             dlog(LOG_ERRSILENT, "Failed to open hash file \"%s\" for write!", name);
             return;
@@ -326,7 +326,7 @@ static void finish_print()
     file_path_append(exp, test.dir, "print.txt", sizeof(exp));
     file_path_append(tmp, test.dir, "print.txt.tmp", sizeof(tmp));
 
-    FILE *expected = fopen(exp, "rb");
+    FILE *expected = fopen_utf8(exp, "rb");
     if (expected == NULL) {
         dlog(LOG_WARN, "Failed to open print file \"%s\", attempting to create", exp);
         fclose(test.print);

--- a/src/memory.c
+++ b/src/memory.c
@@ -6,6 +6,7 @@
 #include "log.h"
 #include "ula.h"
 #include "machine.h"
+#include "file.h"
 
 /* Initializes the DRAM to a pseudo-random state it would have on initial power-on. */
 void memory_init(Memory_t *mem)
@@ -27,7 +28,7 @@ void memory_init(Memory_t *mem)
  * Returns zero on success, non-zero otherwise. */
 int memory_load_rom_16k(Memory_t *mem, char path[])
 {
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
     if (!f) {
         dlog(LOG_ERR, "Failed to load ROM \"%s\"", path);
         return -1;

--- a/src/palette.c
+++ b/src/palette.c
@@ -31,7 +31,7 @@ Palette_t *palette_load(const char *path)
 
     size_t colors = size / 3;
 
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
     if (f == NULL) {
         return NULL;
     }

--- a/src/sna.c
+++ b/src/sna.c
@@ -40,7 +40,7 @@ int sna_state_load(char *path, Machine_t *m)
         file_size = SNA_SIZE_48K;
     }
 
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
     if (f == NULL) {
         dlog(LOG_ERRSILENT, "Failed to open file for reading");
         return -1;

--- a/src/szx_file.c
+++ b/src/szx_file.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include "file.h"
 
 #define U32_FROM_STR(str) (*((uint32_t *)(str)))
 
@@ -9,7 +10,7 @@ const char expected_magic[4] = "ZXST";
 
 bool szx_is_valid_file(char *path)
 {
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
     if (f == NULL) {
         return false;
     }
@@ -47,7 +48,7 @@ void szx_free(SZX_t *szx) {
 
 SZX_t *szx_load_file(char *path)
 {
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
     if (f == NULL) {
         return NULL;
     }
@@ -149,7 +150,7 @@ SZX_t *szx_load_file(char *path)
 
 int szx_save_file(SZX_t *szx, char *path)
 {
-    FILE *f = fopen(path, "wb");
+    FILE *f = fopen_utf8(path, "wb");
     if (f == NULL) {
         return -1;
     }

--- a/src/tape.c
+++ b/src/tape.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "log.h"
+#include "file.h"
 
 struct StandardTapeHeader
 {
@@ -35,7 +36,7 @@ Tape_t *tape_load_from_tap(char *path)
     // followed by the actual block data (in standard Spectrum ROM format).
     // e.g. 13 00 [19 data bytes] 00 01 [256 data bytes] ...
 
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen_utf8(path, "rb");
 
     if (f == NULL) {
         goto error_fopen;

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1,0 +1,348 @@
+// Code from https://github.com/Photosounder/rouziclib
+//
+// MIT License
+// 
+// Copyright (c) 2022 Michel Rouzic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// UTF-8
+
+#include "unicode.h"
+#include <stdlib.h>
+#include <string.h>
+
+int utf8_char_size(const uint8_t *c)
+{
+	const uint8_t	m0x	= 0x80, c0x	= 0x00,
+	      		m10x	= 0xC0, c10x	= 0x80,
+	      		m110x	= 0xE0, c110x	= 0xC0,
+	      		m1110x	= 0xF0, c1110x	= 0xE0,
+	      		m11110x	= 0xF8, c11110x	= 0xF0;
+
+	if ((c[0] & m0x) == c0x)
+		return 1;
+
+	if ((c[0] & m110x) == c110x)
+	if ((c[1] & m10x) == c10x)
+		return 2;
+
+	if ((c[0] & m1110x) == c1110x)
+	if ((c[1] & m10x) == c10x)
+	if ((c[2] & m10x) == c10x)
+		return 3;
+
+	if ((c[0] & m11110x) == c11110x)
+	if ((c[1] & m10x) == c10x)
+	if ((c[2] & m10x) == c10x)
+	if ((c[3] & m10x) == c10x)
+		return 4;
+
+	if ((c[0] & m10x) == c10x)	// not a first UTF-8 byte
+		return 0;
+
+	return -1;			// if c[0] is a first byte but the other bytes don't match
+}
+
+int codepoint_utf8_size(const uint32_t c)
+{
+	if (c < 0x0080) return 1;
+	if (c < 0x0800) return 2;
+	if (c < 0x10000) return 3;
+	if (c < 0x110000) return 4;
+
+	return 0;
+}
+
+uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index)
+{
+	uint32_t v;
+	size_t size;
+	const uint8_t m6 = 63, m5 = 31, m4 = 15, m3 = 7;
+
+	if (c==NULL)
+		return 0;
+
+	size = utf8_char_size(c);
+
+	if (size > 0 && index)
+		*index += size-1;
+
+	switch (size)
+	{
+		case 1:
+			v = c[0];
+			break;
+		case 2:
+			v = c[0] & m5;
+			v = v << 6 | (c[1] & m6);
+			break;
+		case 3:
+			v = c[0] & m4;
+			v = v << 6 | (c[1] & m6);
+			v = v << 6 | (c[2] & m6);
+			break;
+		case 4:
+			v = c[0] & m3;
+			v = v << 6 | (c[1] & m6);
+			v = v << 6 | (c[2] & m6);
+			v = v << 6 | (c[3] & m6);
+			break;
+		case 0:				// not a first UTF-8 byte
+		case -1:			// corrupt UTF-8 letter
+		default:
+			v = -1;
+			break;
+	}
+
+	return v;
+}
+
+uint8_t *sprint_unicode(uint8_t *str, uint32_t c)	// str must be able to hold 1 to 5 bytes and will be null-terminated by this function
+{
+	const uint8_t m6 = 63;
+	const uint8_t	c10x	= 0x80,
+	      		c110x	= 0xC0,
+	      		c1110x	= 0xE0,
+	      		c11110x	= 0xF0;
+
+	if (c < 0x0080)
+	{
+		str[0] = c;
+		if (c > 0)
+			str[1] = '\0';
+	}
+	else if (c < 0x0800)
+	{
+		str[1] = (c & m6) | c10x;
+		c >>= 6;
+		str[0] = c | c110x;
+		str[2] = '\0';
+	}
+	else if (c < 0x10000)
+	{
+		str[2] = (c & m6) | c10x;
+		c >>= 6;
+		str[1] = (c & m6) | c10x;
+		c >>= 6;
+		str[0] = c | c1110x;
+		str[3] = '\0';
+	}
+	else if (c < 0x200000)
+	{
+		str[3] = (c & m6) | c10x;
+		c >>= 6;
+		str[2] = (c & m6) | c10x;
+		c >>= 6;
+		str[1] = (c & m6) | c10x;
+		c >>= 6;
+		str[0] = c | c11110x;
+		str[4] = '\0';
+	}
+	else
+		str[0] = '\0';		// Unicode character doesn't map to UTF-8
+
+	return str;
+}
+
+int find_prev_utf8_char(const uint8_t *str, int pos)
+{
+	if (pos > 0)
+	{
+		do
+		{
+			pos--;
+		}
+		while (utf8_char_size(&str[pos])==0 && pos > 0);
+	}
+
+	return pos;
+}
+
+int find_next_utf8_char(const uint8_t *str, int pos)
+{
+	int il;
+
+	if (pos < strlen(str))
+	{
+		il = utf8_char_size(&str[pos]);
+		if (il==-1 || il==0)	// corrupt letter or non-first byte
+			il = 1;
+		pos += il;
+	}
+
+	return pos;
+}
+
+// UTF-16
+
+size_t strlen_utf16(const uint16_t *str)
+{
+	size_t i;
+
+	for (i=0; ; i++)
+		if (str[i]==0)
+			return i;
+}
+
+int utf16_char_size(const uint16_t *c)
+{
+	if (c[0] <= 0xD7FF || c[0] >= 0xE000)
+		return 1;
+	else if (c[1]==0)			// if there's an abrupt mid-character stream end
+		return 1;
+	else
+		return 2;
+}
+
+int codepoint_utf16_size(uint32_t c)
+{
+	if (c < 0x10000) return 1;
+	if (c < 0x110000) return 2;
+
+	return 0;
+}
+
+uint32_t utf16_to_unicode32(const uint16_t *c, size_t *index)
+{
+	uint32_t v;
+	size_t size;
+
+	size = utf16_char_size(c);
+
+	if (size > 0 && index)
+		*index += size-1;
+
+	switch (size)
+	{
+		case 1:
+			v = c[0];
+			break;
+		case 2:
+			v = c[0] & 0x3FF;
+			v = v << 10 | (c[1] & 0x3FF);
+			v += 0x10000;
+			break;
+	}
+
+	return v;
+}
+
+uint16_t *sprint_utf16(uint16_t *str, uint32_t c)	// str must be able to hold 1 to 3 entries and will be null-terminated by this function
+{
+	int c_size;
+
+	if (str==NULL)
+		return NULL;
+
+	c_size = codepoint_utf16_size(c);
+
+	switch (c_size)
+	{
+		case 1:
+			str[0] = c;
+			if (c > 0)
+				str[1] = '\0';
+			break;
+
+		case 2:
+			c -= 0x10000;
+			str[0] = 0xD800 + (c >> 10);
+			str[1] = 0xDC00 + (c & 0x3FF);
+			str[2] = '\0';
+			break;
+
+		default:
+			str[0] = '\0';
+	}
+
+	return str;
+}
+
+size_t strlen_utf8_to_utf16(const uint8_t *str)
+{
+	size_t i, count;
+	uint32_t c;
+
+	for (i=0, count=0; ; i++)
+	{
+		if (str[i]==0)
+			return count;
+
+		c = utf8_to_unicode32(&str[i], &i);
+		count += codepoint_utf16_size(c);
+	}
+}
+
+size_t strlen_utf16_to_utf8(const uint16_t *str)
+{
+	size_t i, count;
+	uint32_t c;
+
+	for (i=0, count=0; ; i++)
+	{
+		if (str[i]==0)
+			return count;
+
+		c = utf16_to_unicode32(&str[i], &i);
+		count += codepoint_utf8_size(c);
+	}
+}
+
+uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16)
+{
+	size_t i, j;
+	uint32_t c;
+
+	if (utf8==NULL)
+		return NULL;
+
+	if (utf16==NULL)
+		utf16 = calloc(strlen_utf8_to_utf16(utf8) + 1, sizeof(uint16_t));
+
+	for (i=0, j=0, c=1; c; i++)
+	{
+		c = utf8_to_unicode32(&utf8[i], &i);
+		sprint_utf16(&utf16[j], c);
+		j += codepoint_utf16_size(c);
+	}
+
+	return utf16;
+}
+
+uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8)
+{
+	size_t i, j;
+	uint32_t c;
+
+	if (utf16==NULL)
+		return NULL;
+
+	if (utf8==NULL)
+		utf8 = calloc(strlen_utf16_to_utf8(utf16) + 1, sizeof(uint8_t));
+
+	for (i=0, j=0, c=1; c; i++)
+	{
+		c = utf16_to_unicode32(&utf16[i], &i);
+		sprint_unicode(&utf8[j], c);
+		j += codepoint_utf8_size(c);
+	}
+
+	return utf8;
+}

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -30,319 +30,306 @@
 
 int utf8_char_size(const uint8_t *c)
 {
-	const uint8_t	m0x	= 0x80, c0x	= 0x00,
-	      		m10x	= 0xC0, c10x	= 0x80,
-	      		m110x	= 0xE0, c110x	= 0xC0,
-	      		m1110x	= 0xF0, c1110x	= 0xE0,
-	      		m11110x	= 0xF8, c11110x	= 0xF0;
+    const uint8_t m0x     = 0x80, c0x     = 0x00,
+                  m10x    = 0xC0, c10x    = 0x80,
+                  m110x   = 0xE0, c110x   = 0xC0,
+                  m1110x  = 0xF0, c1110x  = 0xE0,
+                  m11110x = 0xF8, c11110x = 0xF0;
 
-	if ((c[0] & m0x) == c0x)
-		return 1;
+    if ((c[0] & m0x) == c0x)
+        return 1;
 
-	if ((c[0] & m110x) == c110x)
-	if ((c[1] & m10x) == c10x)
-		return 2;
+    if ((c[0] & m110x) == c110x)
+    if ((c[1] & m10x) == c10x)
+        return 2;
 
-	if ((c[0] & m1110x) == c1110x)
-	if ((c[1] & m10x) == c10x)
-	if ((c[2] & m10x) == c10x)
-		return 3;
+    if ((c[0] & m1110x) == c1110x)
+    if ((c[1] & m10x) == c10x)
+    if ((c[2] & m10x) == c10x)
+        return 3;
 
-	if ((c[0] & m11110x) == c11110x)
-	if ((c[1] & m10x) == c10x)
-	if ((c[2] & m10x) == c10x)
-	if ((c[3] & m10x) == c10x)
-		return 4;
+    if ((c[0] & m11110x) == c11110x)
+    if ((c[1] & m10x) == c10x)
+    if ((c[2] & m10x) == c10x)
+    if ((c[3] & m10x) == c10x)
+        return 4;
 
-	if ((c[0] & m10x) == c10x)	// not a first UTF-8 byte
-		return 0;
+    if ((c[0] & m10x) == c10x) // not a first UTF-8 byte
+        return 0;
 
-	return -1;			// if c[0] is a first byte but the other bytes don't match
+    return -1; // if c[0] is a first byte but the other bytes don't match
 }
 
 int codepoint_utf8_size(const uint32_t c)
 {
-	if (c < 0x0080) return 1;
-	if (c < 0x0800) return 2;
-	if (c < 0x10000) return 3;
-	if (c < 0x110000) return 4;
+    if (c < 0x0080)   return 1;
+    if (c < 0x0800)   return 2;
+    if (c < 0x10000)  return 3;
+    if (c < 0x110000) return 4;
 
-	return 0;
+    return 0;
 }
 
 uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index)
 {
-	uint32_t v;
-	size_t size;
-	const uint8_t m6 = 63, m5 = 31, m4 = 15, m3 = 7;
+    uint32_t v;
+    size_t size;
+    const uint8_t m6 = 63, m5 = 31, m4 = 15, m3 = 7;
 
-	if (c==NULL)
-		return 0;
+    if (c == NULL)
+        return 0;
 
-	size = utf8_char_size(c);
+    size = utf8_char_size(c);
 
-	if (size > 0 && index)
-		*index += size-1;
+    if (size > 0 && index)
+        *index += size-1;
 
-	switch (size)
-	{
-		case 1:
-			v = c[0];
-			break;
-		case 2:
-			v = c[0] & m5;
-			v = v << 6 | (c[1] & m6);
-			break;
-		case 3:
-			v = c[0] & m4;
-			v = v << 6 | (c[1] & m6);
-			v = v << 6 | (c[2] & m6);
-			break;
-		case 4:
-			v = c[0] & m3;
-			v = v << 6 | (c[1] & m6);
-			v = v << 6 | (c[2] & m6);
-			v = v << 6 | (c[3] & m6);
-			break;
-		case 0:				// not a first UTF-8 byte
-		case -1:			// corrupt UTF-8 letter
-		default:
-			v = -1;
-			break;
-	}
+    switch (size)
+    {
+    case 1:
+        v = c[0];
+        break;
+    case 2:
+        v = c[0] & m5;
+        v = v << 6 | (c[1] & m6);
+        break;
+    case 3:
+        v = c[0] & m4;
+        v = v << 6 | (c[1] & m6);
+        v = v << 6 | (c[2] & m6);
+        break;
+    case 4:
+        v = c[0] & m3;
+        v = v << 6 | (c[1] & m6);
+        v = v << 6 | (c[2] & m6);
+        v = v << 6 | (c[3] & m6);
+        break;
+    case 0:  // not a first UTF-8 byte
+    case -1: // corrupt UTF-8 letter
+    default:
+        v = -1;
+        break;
+    }
 
-	return v;
+    return v;
 }
 
-uint8_t *sprint_unicode(uint8_t *str, uint32_t c)	// str must be able to hold 1 to 5 bytes and will be null-terminated by this function
+// str must be able to hold 1 to 5 bytes and will be null-terminated by this function
+uint8_t *sprint_unicode(uint8_t *str, uint32_t c)
 {
-	const uint8_t m6 = 63;
-	const uint8_t	c10x	= 0x80,
-	      		c110x	= 0xC0,
-	      		c1110x	= 0xE0,
-	      		c11110x	= 0xF0;
+    const uint8_t m6 = 63;
+    const uint8_t c10x    = 0x80,
+                  c110x   = 0xC0,
+                  c1110x  = 0xE0,
+                  c11110x = 0xF0;
 
-	if (c < 0x0080)
-	{
-		str[0] = c;
-		if (c > 0)
-			str[1] = '\0';
-	}
-	else if (c < 0x0800)
-	{
-		str[1] = (c & m6) | c10x;
-		c >>= 6;
-		str[0] = c | c110x;
-		str[2] = '\0';
-	}
-	else if (c < 0x10000)
-	{
-		str[2] = (c & m6) | c10x;
-		c >>= 6;
-		str[1] = (c & m6) | c10x;
-		c >>= 6;
-		str[0] = c | c1110x;
-		str[3] = '\0';
-	}
-	else if (c < 0x200000)
-	{
-		str[3] = (c & m6) | c10x;
-		c >>= 6;
-		str[2] = (c & m6) | c10x;
-		c >>= 6;
-		str[1] = (c & m6) | c10x;
-		c >>= 6;
-		str[0] = c | c11110x;
-		str[4] = '\0';
-	}
-	else
-		str[0] = '\0';		// Unicode character doesn't map to UTF-8
+    if (c < 0x0080) {
+        str[0] = c;
+        if (c > 0)
+            str[1] = '\0';
+    } else if (c < 0x0800) {
+        str[1] = (c & m6) | c10x;
+        c >>= 6;
+        str[0] = c | c110x;
+        str[2] = '\0';
+    } else if (c < 0x10000) {
+        str[2] = (c & m6) | c10x;
+        c >>= 6;
+        str[1] = (c & m6) | c10x;
+        c >>= 6;
+        str[0] = c | c1110x;
+        str[3] = '\0';
+    } else if (c < 0x200000) {
+        str[3] = (c & m6) | c10x;
+        c >>= 6;
+        str[2] = (c & m6) | c10x;
+        c >>= 6;
+        str[1] = (c & m6) | c10x;
+        c >>= 6;
+        str[0] = c | c11110x;
+        str[4] = '\0';
+    } else {
+        str[0] = '\0'; // Unicode character doesn't map to UTF-8
+    }
 
-	return str;
+    return str;
 }
 
 int find_prev_utf8_char(const uint8_t *str, int pos)
 {
-	if (pos > 0)
-	{
-		do
-		{
-			pos--;
-		}
-		while (utf8_char_size(&str[pos])==0 && pos > 0);
-	}
+    if (pos > 0) {
+        do {
+            pos--;
+        } while (utf8_char_size(&str[pos]) == 0 && pos > 0);
+    }
 
-	return pos;
+    return pos;
 }
 
 int find_next_utf8_char(const uint8_t *str, int pos)
 {
-	int il;
+    int il;
 
-	if (pos < strlen(str))
-	{
-		il = utf8_char_size(&str[pos]);
-		if (il==-1 || il==0)	// corrupt letter or non-first byte
-			il = 1;
-		pos += il;
-	}
+    if (pos < strlen(str)) {
+        il = utf8_char_size(&str[pos]);
+        if (il==-1 || il==0) // corrupt letter or non-first byte
+            il = 1;
+        pos += il;
+    }
 
-	return pos;
+    return pos;
 }
 
 // UTF-16
 
 size_t strlen_utf16(const uint16_t *str)
 {
-	size_t i;
+    size_t i;
 
-	for (i=0; ; i++)
-		if (str[i]==0)
-			return i;
+    for (i = 0; ; i++)
+        if (str[i] == 0)
+            return i;
 }
 
 int utf16_char_size(const uint16_t *c)
 {
-	if (c[0] <= 0xD7FF || c[0] >= 0xE000)
-		return 1;
-	else if (c[1]==0)			// if there's an abrupt mid-character stream end
-		return 1;
-	else
-		return 2;
+    if (c[0] <= 0xD7FF || c[0] >= 0xE000)
+        return 1;
+    else if (c[1] == 0) // if there's an abrupt mid-character stream end
+        return 1;
+    else
+        return 2;
 }
 
 int codepoint_utf16_size(uint32_t c)
 {
-	if (c < 0x10000) return 1;
-	if (c < 0x110000) return 2;
+    if (c < 0x10000)  return 1;
+    if (c < 0x110000) return 2;
 
-	return 0;
+    return 0;
 }
 
 uint32_t utf16_to_unicode32(const uint16_t *c, size_t *index)
 {
-	uint32_t v;
-	size_t size;
+    uint32_t v;
+    size_t size;
 
-	size = utf16_char_size(c);
+    size = utf16_char_size(c);
 
-	if (size > 0 && index)
-		*index += size-1;
+    if (size > 0 && index)
+        *index += size-1;
 
-	switch (size)
-	{
-		case 1:
-			v = c[0];
-			break;
-		case 2:
-			v = c[0] & 0x3FF;
-			v = v << 10 | (c[1] & 0x3FF);
-			v += 0x10000;
-			break;
-	}
+    switch (size)
+    {
+    case 1:
+        v = c[0];
+        break;
+    case 2:
+        v = c[0] & 0x3FF;
+        v = v << 10 | (c[1] & 0x3FF);
+        v += 0x10000;
+        break;
+    }
 
-	return v;
+    return v;
 }
 
-uint16_t *sprint_utf16(uint16_t *str, uint32_t c)	// str must be able to hold 1 to 3 entries and will be null-terminated by this function
+// str must be able to hold 1 to 3 entries and will be null-terminated by this function
+uint16_t *sprint_utf16(uint16_t *str, uint32_t c)
 {
-	int c_size;
+    int c_size;
 
-	if (str==NULL)
-		return NULL;
+    if (str == NULL)
+        return NULL;
 
-	c_size = codepoint_utf16_size(c);
+    c_size = codepoint_utf16_size(c);
 
-	switch (c_size)
-	{
-		case 1:
-			str[0] = c;
-			if (c > 0)
-				str[1] = '\0';
-			break;
+    switch (c_size)
+    {
+    case 1:
+        str[0] = c;
+        if (c > 0)
+            str[1] = '\0';
+        break;
+    case 2:
+        c -= 0x10000;
+        str[0] = 0xD800 + (c >> 10);
+        str[1] = 0xDC00 + (c & 0x3FF);
+        str[2] = '\0';
+        break;
+    default:
+        str[0] = '\0';
+    }
 
-		case 2:
-			c -= 0x10000;
-			str[0] = 0xD800 + (c >> 10);
-			str[1] = 0xDC00 + (c & 0x3FF);
-			str[2] = '\0';
-			break;
-
-		default:
-			str[0] = '\0';
-	}
-
-	return str;
+    return str;
 }
 
 size_t strlen_utf8_to_utf16(const uint8_t *str)
 {
-	size_t i, count;
-	uint32_t c;
+    size_t i, count;
+    uint32_t c;
 
-	for (i=0, count=0; ; i++)
-	{
-		if (str[i]==0)
-			return count;
+    for (i = 0, count = 0; ; i++) {
+        if (str[i] == 0)
+            return count;
 
-		c = utf8_to_unicode32(&str[i], &i);
-		count += codepoint_utf16_size(c);
-	}
+        c = utf8_to_unicode32(&str[i], &i);
+        count += codepoint_utf16_size(c);
+    }
 }
 
 size_t strlen_utf16_to_utf8(const uint16_t *str)
 {
-	size_t i, count;
-	uint32_t c;
+    size_t i, count;
+    uint32_t c;
 
-	for (i=0, count=0; ; i++)
-	{
-		if (str[i]==0)
-			return count;
+    for (i = 0, count = 0; ; i++) {
+        if (str[i] == 0)
+            return count;
 
-		c = utf16_to_unicode32(&str[i], &i);
-		count += codepoint_utf8_size(c);
-	}
+        c = utf16_to_unicode32(&str[i], &i);
+        count += codepoint_utf8_size(c);
+    }
 }
 
 uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16)
 {
-	size_t i, j;
-	uint32_t c;
+    size_t i, j;
+    uint32_t c;
 
-	if (utf8==NULL)
-		return NULL;
+    if (utf8 == NULL)
+        return NULL;
 
-	if (utf16==NULL)
-		utf16 = calloc(strlen_utf8_to_utf16(utf8) + 1, sizeof(uint16_t));
+    if (utf16 == NULL)
+        utf16 = calloc(strlen_utf8_to_utf16(utf8) + 1, sizeof(uint16_t));
 
-	for (i=0, j=0, c=1; c; i++)
-	{
-		c = utf8_to_unicode32(&utf8[i], &i);
-		sprint_utf16(&utf16[j], c);
-		j += codepoint_utf16_size(c);
-	}
+    for (i = 0, j = 0, c = 1; c; i++)
+    {
+        c = utf8_to_unicode32(&utf8[i], &i);
+        sprint_utf16(&utf16[j], c);
+        j += codepoint_utf16_size(c);
+    }
 
-	return utf16;
+    return utf16;
 }
 
 uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8)
 {
-	size_t i, j;
-	uint32_t c;
+    size_t i, j;
+    uint32_t c;
 
-	if (utf16==NULL)
-		return NULL;
+    if (utf16 == NULL)
+        return NULL;
 
-	if (utf8==NULL)
-		utf8 = calloc(strlen_utf16_to_utf8(utf16) + 1, sizeof(uint8_t));
+    if (utf8 == NULL)
+        utf8 = calloc(strlen_utf16_to_utf8(utf16) + 1, sizeof(uint8_t));
 
-	for (i=0, j=0, c=1; c; i++)
-	{
-		c = utf16_to_unicode32(&utf16[i], &i);
-		sprint_unicode(&utf8[j], c);
-		j += codepoint_utf8_size(c);
-	}
+    for (i = 0, j = 0, c = 1; c; i++)
+    {
+        c = utf16_to_unicode32(&utf16[i], &i);
+        sprint_unicode(&utf8[j], c);
+        j += codepoint_utf8_size(c);
+    }
 
-	return utf8;
+    return utf8;
 }

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -28,13 +28,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-int utf8_char_size(const uint8_t *c)
+int utf8_char_size(const char *c)
 {
-    const uint8_t m0x     = 0x80, c0x     = 0x00,
-                  m10x    = 0xC0, c10x    = 0x80,
-                  m110x   = 0xE0, c110x   = 0xC0,
-                  m1110x  = 0xF0, c1110x  = 0xE0,
-                  m11110x = 0xF8, c11110x = 0xF0;
+    const char m0x     = 0x80, c0x     = 0x00,
+               m10x    = 0xC0, c10x    = 0x80,
+               m110x   = 0xE0, c110x   = 0xC0,
+               m1110x  = 0xF0, c1110x  = 0xE0,
+               m11110x = 0xF8, c11110x = 0xF0;
 
     if ((c[0] & m0x) == c0x)
         return 1;
@@ -70,11 +70,11 @@ int codepoint_utf8_size(const uint32_t c)
     return 0;
 }
 
-uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index)
+uint32_t utf8_to_unicode32(const char *c, size_t *index)
 {
     uint32_t v;
     size_t size;
-    const uint8_t m6 = 63, m5 = 31, m4 = 15, m3 = 7;
+    const char m6 = 63, m5 = 31, m4 = 15, m3 = 7;
 
     if (c == NULL)
         return 0;
@@ -115,13 +115,13 @@ uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index)
 }
 
 // str must be able to hold 1 to 5 bytes and will be null-terminated by this function
-uint8_t *sprint_unicode(uint8_t *str, uint32_t c)
+char *sprint_unicode(char *str, uint32_t c)
 {
-    const uint8_t m6 = 63;
-    const uint8_t c10x    = 0x80,
-                  c110x   = 0xC0,
-                  c1110x  = 0xE0,
-                  c11110x = 0xF0;
+    const char m6 = 63;
+    const char c10x    = 0x80,
+               c110x   = 0xC0,
+               c1110x  = 0xE0,
+               c11110x = 0xF0;
 
     if (c < 0x0080) {
         str[0] = c;
@@ -155,7 +155,7 @@ uint8_t *sprint_unicode(uint8_t *str, uint32_t c)
     return str;
 }
 
-int find_prev_utf8_char(const uint8_t *str, int pos)
+int find_prev_utf8_char(const char *str, size_t pos)
 {
     if (pos > 0) {
         do {
@@ -166,7 +166,7 @@ int find_prev_utf8_char(const uint8_t *str, int pos)
     return pos;
 }
 
-int find_next_utf8_char(const uint8_t *str, int pos)
+int find_next_utf8_char(const char *str, size_t pos)
 {
     int il;
 
@@ -264,7 +264,7 @@ uint16_t *sprint_utf16(uint16_t *str, uint32_t c)
     return str;
 }
 
-size_t strlen_utf8_to_utf16(const uint8_t *str)
+size_t strlen_utf8_to_utf16(const char *str)
 {
     size_t i, count;
     uint32_t c;
@@ -292,7 +292,7 @@ size_t strlen_utf16_to_utf8(const uint16_t *str)
     }
 }
 
-uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16)
+uint16_t *utf8_to_utf16(const char *utf8, uint16_t *utf16)
 {
     size_t i, j;
     uint32_t c;
@@ -300,11 +300,12 @@ uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16)
     if (utf8 == NULL)
         return NULL;
 
-    if (utf16 == NULL)
+    if (utf16 == NULL) {
         utf16 = calloc(strlen_utf8_to_utf16(utf8) + 1, sizeof(uint16_t));
+        if (utf16 == NULL) return NULL; 
+    }
 
-    for (i = 0, j = 0, c = 1; c; i++)
-    {
+    for (i = 0, j = 0, c = 1; c; i++) {
         c = utf8_to_unicode32(&utf8[i], &i);
         sprint_utf16(&utf16[j], c);
         j += codepoint_utf16_size(c);
@@ -313,7 +314,7 @@ uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16)
     return utf16;
 }
 
-uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8)
+char *utf16_to_utf8(const uint16_t *utf16, char *utf8)
 {
     size_t i, j;
     uint32_t c;
@@ -321,11 +322,12 @@ uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8)
     if (utf16 == NULL)
         return NULL;
 
-    if (utf8 == NULL)
-        utf8 = calloc(strlen_utf16_to_utf8(utf16) + 1, sizeof(uint8_t));
+    if (utf8 == NULL) {
+        utf8 = calloc(strlen_utf16_to_utf8(utf16) + 1, sizeof(char));
+        if (utf8 == NULL) return NULL; 
+    }
 
-    for (i = 0, j = 0, c = 1; c; i++)
-    {
+    for (i = 0, j = 0, c = 1; c; i++) {
         c = utf16_to_unicode32(&utf16[i], &i);
         sprint_unicode(&utf8[j], c);
         j += codepoint_utf8_size(c);

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -6,22 +6,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern int utf8_char_size(const uint8_t *c);
+extern int utf8_char_size(const char *c);
 extern int codepoint_utf8_size(const uint32_t c);
-extern uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index);
-extern uint8_t *sprint_unicode(uint8_t *str, uint32_t c);
-extern int find_prev_utf8_char(const uint8_t *str, int pos);
-extern int find_next_utf8_char(const uint8_t *str, int pos);
+extern uint32_t utf8_to_unicode32(const char *c, size_t *index);
+extern char *sprint_unicode(char *str, uint32_t c);
+extern int find_prev_utf8_char(const char *str, size_t pos);
+extern int find_next_utf8_char(const char *str, size_t pos);
 
 extern size_t strlen_utf16(const uint16_t *str);
 extern int utf16_char_size(const uint16_t *c);
 extern int codepoint_utf16_size(uint32_t c);
 extern uint32_t utf16_to_unicode32(const uint16_t *c, size_t *index);
 extern uint16_t *sprint_utf16(uint16_t *str, uint32_t c);
-extern size_t strlen_utf8_to_utf16(const uint8_t *str);
+extern size_t strlen_utf8_to_utf16(const char *str);
 extern size_t strlen_utf16_to_utf8(const uint16_t *str);
-extern uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16);
-extern uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8);
+extern uint16_t *utf8_to_utf16(const char *utf8, uint16_t *utf16);
+extern char *utf16_to_utf8(const uint16_t *utf16, char *utf8);
 
 #define utf8_to_wchar(utf8, wchar)	utf8_to_utf16(utf8, wchar)
 #define wchar_to_utf8(wchar, utf8)	utf16_to_utf8(wchar, utf8)

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -1,0 +1,27 @@
+// Code from https://github.com/Photosounder/rouziclib
+// See unicode.c for license details
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern int utf8_char_size(const uint8_t *c);
+extern int codepoint_utf8_size(const uint32_t c);
+extern uint32_t utf8_to_unicode32(const uint8_t *c, size_t *index);
+extern uint8_t *sprint_unicode(uint8_t *str, uint32_t c);
+extern int find_prev_utf8_char(const uint8_t *str, int pos);
+extern int find_next_utf8_char(const uint8_t *str, int pos);
+
+extern size_t strlen_utf16(const uint16_t *str);
+extern int utf16_char_size(const uint16_t *c);
+extern int codepoint_utf16_size(uint32_t c);
+extern uint32_t utf16_to_unicode32(const uint16_t *c, size_t *index);
+extern uint16_t *sprint_utf16(uint16_t *str, uint32_t c);
+extern size_t strlen_utf8_to_utf16(const uint8_t *str);
+extern size_t strlen_utf16_to_utf8(const uint16_t *str);
+extern uint16_t *utf8_to_utf16(const uint8_t *utf8, uint16_t *utf16);
+extern uint8_t *utf16_to_utf8(const uint16_t *utf16, uint8_t *utf8);
+
+#define utf8_to_wchar(utf8, wchar)	utf8_to_utf16(utf8, wchar)
+#define wchar_to_utf8(wchar, utf8)	utf16_to_utf8(wchar, utf8)

--- a/src/win32/gui_windows.c
+++ b/src/win32/gui_windows.c
@@ -6,6 +6,7 @@
 #include "../machine.h"
 #include "../palette.h"
 #include "../file.h"
+#include "../unicode.h"
 
 static WNDPROC sdl_wndproc;
 static HMENU menu = NULL;
@@ -92,8 +93,8 @@ void menu_palette_init()
 
 void on_file_open(HWND hwnd)
 {
-    OPENFILENAME ofn;
-    char file[260];
+    OPENFILENAMEW ofn;
+    wchar_t file[2048];
 
     ZeroMemory(&ofn, sizeof(ofn));
     ofn.lStructSize = sizeof(ofn);
@@ -101,22 +102,29 @@ void on_file_open(HWND hwnd)
     ofn.lpstrFile = file;
     ofn.lpstrFile[0] = 0;
     ofn.nMaxFile = sizeof(file);
-    ofn.lpstrFilter = "All supported files\0*.tap;*.szx*\0";
+    ofn.lpstrFilter = L"All supported files\0*.tap;*.szx*\0";
     ofn.nFilterIndex = 1;
     ofn.lpstrFileTitle = NULL;
     ofn.nMaxFileTitle = 0;
     ofn.lpstrInitialDir = NULL;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
-    if (GetOpenFileName(&ofn) == TRUE) {
-        machine_open_file(ofn.lpstrFile);
+    if (GetOpenFileNameW(&ofn) != TRUE) {
+        return;
     }
+
+    char *str = utf16_to_utf8(ofn.lpstrFile, NULL);
+    if (str == NULL) {
+        return;
+    }
+    machine_open_file(str);
+    free(str);
 }
 
 void on_file_save(HWND hwnd)
 {
-    OPENFILENAME ofn;
-    char file[260];
+    OPENFILENAMEW ofn;
+    wchar_t file[2048];
 
     ZeroMemory(&ofn, sizeof(ofn));
     ofn.lStructSize = sizeof(ofn);
@@ -124,17 +132,24 @@ void on_file_save(HWND hwnd)
     ofn.lpstrFile = file;
     ofn.lpstrFile[0] = 0;
     ofn.nMaxFile = sizeof(file);
-    ofn.lpstrFilter = "SZX state\0*.szx\0";
-    ofn.lpstrDefExt = "szx";
+    ofn.lpstrFilter = L"SZX state\0*.szx\0";
+    ofn.lpstrDefExt = L"szx";
     ofn.nFilterIndex = 1;
     ofn.lpstrFileTitle = NULL;
     ofn.nMaxFileTitle = 0;
     ofn.lpstrInitialDir = NULL;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
 
-    if (GetSaveFileName(&ofn) == TRUE) {
-        machine_save_file(ofn.lpstrFile);
+    if (GetSaveFileNameW(&ofn) != TRUE) {
+        return;
     }
+
+    char *str = utf16_to_utf8(ofn.lpstrFile, NULL);
+    if (str == NULL) {
+        return;
+    }
+    machine_save_file(str);
+    free(str);
 }
 
 LRESULT CALLBACK wnd_proc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM lparam)


### PR DESCRIPTION
Everything uses a `fopen_utf8()` macro now, which automagically handles string conversion (if necessary). Some other Windows-specific code (i.e. menu bar contents, about box) could use adjustments as well, but it's not really needed at the moment as the contents are hardcoded.

Based on `unicode.c` from https://github.com/Photosounder/rouziclib as well as https://github.com/Photosounder/fopen_utf8